### PR TITLE
rework the concurrency story to use STM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: true
+language: haskell
+
+git:
+  depth: 5
+
+cabal: "2.4"
+ghc: "8.8.3"
+env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
+
+cache:
+  directories:
+  - "$HOME/.stack"
+  - "$TRAVIS_BUILD_DIR/.stack-work"
+
+install:
+  - |
+    # install stack
+    curl -sSL https://get.haskellstack.org/ | sh
+
+    # build project with stack
+    stack --version
+    stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+
+script:
+  - stack test --system-ghc
+
+notifications:
+  email: false

--- a/Main.hs
+++ b/Main.hs
@@ -190,8 +190,8 @@ game room = websocketsOr WebSockets.defaultConnectionOptions handleConn fallback
       conn <- liftIO $ WebSockets.acceptRequest pendingConn
       chan <- atomically newTChan
       debug $ "accepted connection"
-      withPingThread conn 30 $ void $
-        race (handleMessages conn chan 0) (receive conn chan)
+      withPingThread conn 30 $
+        race_ (handleMessages conn chan 0) (receive conn chan)
       debug $ "dropped connection" -- <> displayShow connId
     handleMessages conn chan last = do
       action <- atomically $ do

--- a/Main.hs
+++ b/Main.hs
@@ -9,10 +9,31 @@ import Network.HTTP.Types
 import qualified Network.Wai as Wai
 import qualified Network.WebSockets as WebSockets
 import Network.WebSockets (WebSocketsData)
+import qualified Options.Applicative as Options
 import RIO
 import qualified RIO.ByteString.Lazy as BL
 import qualified RIO.Map as Map
 import Web (WebHandler, run, sourceAddress, websocketsOr, withPingThread)
+
+data Opts
+  = Opts {optPort :: Int}
+
+getOpts :: IO Opts
+getOpts = Options.execParser parser
+  where
+    parser =
+      Options.info
+        ( Options.helper
+            <*> ( Opts
+                    <$> Options.option
+                      Options.auto
+                      ( Options.long "port" <> Options.short 'p' <> Options.value 8787
+                          <> Options.metavar "PORT"
+                          <> Options.help "listen port"
+                      )
+                )
+        )
+        (Options.fullDesc <> Options.progDesc "Websockets puzzle server." <> Options.header "puzzld")
 
 type Key = Text
 
@@ -223,5 +244,6 @@ game room = websocketsOr WebSockets.defaultConnectionOptions handleConn fallback
 
 main :: IO ()
 main = runApp $ do
-  info $ "listening on port 8787"
-  run 8787 toplevel
+  Opts port <- liftIO getOpts
+  info $ "listening on port " <> display port
+  run port toplevel

--- a/Web.hs
+++ b/Web.hs
@@ -8,7 +8,6 @@ module Web
     websocketsOr,
     withPingThread,
     sourceAddress,
-    receiveDataMessageOrClosed,
   )
 where
 
@@ -45,18 +44,6 @@ websocketsOr connectionOptions app backup =
 withPingThread :: MonadUnliftIO m => WebSockets.Connection -> Int -> m a -> m a
 withPingThread conn interval action = withRunInIO $ \runInIO ->
   WebSockets.withPingThread conn interval (return ()) (runInIO action)
-
-receiveDataMessageOrClosed :: WebSockets.Connection -> IO (Maybe WebSockets.DataMessage)
-receiveDataMessageOrClosed conn =
-  ( do
-      msg <- WebSockets.receiveDataMessage conn
-      return $ Just msg
-  )
-    `catch` ( \e -> case e of
-                WebSockets.CloseRequest _ _ -> return Nothing
-                WebSockets.ConnectionClosed -> return Nothing
-                _ -> throwIO e
-            )
 
 sourceAddress :: Wai.Request -> Utf8Builder
 sourceAddress req = fromMaybe socketAddr headerAddr

--- a/puzzld.cabal
+++ b/puzzld.cabal
@@ -21,6 +21,7 @@ executable puzzld
                        aeson,
                        containers,
                        http-types,
+                       optparse-applicative,
                        rio,
                        wai,
                        wai-websockets,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
-resolver: lts-15.3
+resolver: lts-15.6
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 491373
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/3.yaml
-    sha256: 29e9ff61b8bf4b4fcff55cde3ac106ebb971f0d21331dccac9eee63374fa6ca8
-  original: lts-15.3
+    size: 491387
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/6.yaml
+    sha256: 8d81505a6de861e167a58534ab62330afb75bfa108735c7db1204f7ef2a39d79
+  original: lts-15.6


### PR DESCRIPTION
- each connection gets a receiving thread that just writes messages
  to a channel as they come in
- rooms are now stored in TVars, and the main websocket thread
  "selects" between messages on its receive channel and new events
  in the room history via STM
- we no longer try to avoid exceptions on shutdown, instead letting
  the close exceptions tear down both threads

TODO:
- clean up the code
- catch and log the exceptions
- fix event history data structure use to work less suboptimally
  with this (i.e., don't filter the whole sequence all the time)
- test that it still works